### PR TITLE
Emergency

### DIFF
--- a/src/apis/study.js
+++ b/src/apis/study.js
@@ -3,7 +3,7 @@ import ococ from './core';
 const ROUTE = 'study';
 
 export const postStudyType = async (level, studyType = 'click') => {
-  await ococ.post(`/${ROUTE}`, { level, studyType });
+  return await ococ.post(`/${ROUTE}`, { level, studyType });
 };
 
 export const sendStudyResult = async (results, studyId) => {

--- a/src/pages/LevelSelection/index.jsx
+++ b/src/pages/LevelSelection/index.jsx
@@ -22,8 +22,11 @@ function LevelSelection() {
   const mutation = useMutation({
     mutationFn: _data => {
       // [Todo] 이거 정상 작동되는지 확인 필요
-      const data = study.postStudyType(_data).data.data;
-      dispatch(studySlice.actions.setAllCorpus({ datasets: data.datasets, studyId: data.study.id }));
+      study.postStudyType(_data).then(res => {
+        console.log(res.data.data);
+        const data = res.data.data;
+        dispatch(studySlice.actions.setAllCorpus({ datasets: data.datasets, studyId: data.study.id }));
+      });
     },
     onSuccess: () => {
       dispatch(studySlice.actions.increaseStage());


### PR DESCRIPTION
### [!] Click 영작 페이지 이슈
- 기존 영작 페이지 이탈 시, useEffect로 로컬저장소에 있는 데이터 날리는 작업이 이루어지지 않고 있음
- 게임 시작 후, korean 데이터가 느리게 나옴
- 게임 시작 후, 새로고침을 해야 버튼이 활성화